### PR TITLE
feat: add GLM window manager and usage scripts

### DIFF
--- a/plugins/glm-plan-usage/scripts/.gitignore
+++ b/plugins/glm-plan-usage/scripts/.gitignore
@@ -1,0 +1,2 @@
+*.log
+__pycache__/

--- a/plugins/glm-plan-usage/scripts/daily-summary.py
+++ b/plugins/glm-plan-usage/scripts/daily-summary.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+GLM Daily Usage Summary — queries usage and sends a Discord DM report.
+Designed to run as a cron job (zero Hermes token cost).
+
+Usage:
+    python3 daily-summary.py                 # Full run (query + send DM)
+    python3 daily-summary.py --dry-run       # Print report without sending DM
+    python3 daily-summary.py --send-only     # Send last cached report
+"""
+
+import json
+import logging
+import os
+import sys
+import time
+import ssl
+import argparse
+import urllib.request
+import urllib.parse
+from datetime import datetime, timedelta, timezone
+
+# Force Asia/Shanghai
+os.environ["TZ"] = "Asia/Shanghai"
+time.tzset()
+
+# --- Config ---
+GLM_CONFIG_PATH = os.path.expanduser("~/.glm-config")
+DISCORD_CONFIG_PATH = os.path.expanduser("~/.discord-config")
+CACHE_PATH = os.path.expanduser("~/.glm-daily-summary.json")
+LOG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
+LOG_FILE = os.path.join(LOG_DIR, "daily-summary.log")
+
+log = logging.getLogger("daily-summary")
+
+
+def setup_logging():
+    """Configure logging to both file and stdout."""
+    os.makedirs(LOG_DIR, exist_ok=True)
+    log.setLevel(logging.DEBUG)
+
+    fh = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    fh.setLevel(logging.DEBUG)
+    fh.setFormatter(logging.Formatter("%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"))
+
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setLevel(logging.INFO)
+    sh.setFormatter(logging.Formatter("%(asctime)s %(message)s", datefmt="%H:%M:%S"))
+
+    log.addHandler(fh)
+    log.addHandler(sh)
+
+
+def load_key_value_file(path: str) -> dict:
+    config = {}
+    with open(path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            eq = line.find("=")
+            if eq == -1:
+                continue
+            config[line[:eq].strip()] = line[eq + 1:].strip()
+    return config
+
+
+def api_get(url: str, auth_token: str) -> dict:
+    ctx = ssl.create_default_context()
+    req = urllib.request.Request(url, headers={
+        "Authorization": auth_token,
+        "Accept-Language": "en-US,en",
+        "Content-Type": "application/json",
+        "User-Agent": "GLM-DailySummary/1.0",
+    })
+    with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+        data = json.loads(resp.read().decode())
+        return data.get("data", data)
+
+
+def send_discord_dm(bot_token: str, user_id: str, message: str) -> bool:
+    ctx = ssl.create_default_context()
+    headers = {
+        "Authorization": f"Bot {bot_token}",
+        "Content-Type": "application/json",
+        "User-Agent": "GLM-DailySummary/1.0",
+    }
+    try:
+        dm_payload = json.dumps({"recipient_id": user_id}).encode()
+        dm_req = urllib.request.Request(
+            "https://discord.com/api/v10/users/@me/channels",
+            data=dm_payload, headers=headers, method="POST",
+        )
+        with urllib.request.urlopen(dm_req, context=ctx, timeout=15) as resp:
+            channel_id = json.loads(resp.read().decode())["id"]
+
+        msg_payload = json.dumps({"content": message}).encode()
+        msg_req = urllib.request.Request(
+            f"https://discord.com/api/v10/channels/{channel_id}/messages",
+            data=msg_payload, headers=headers, method="POST",
+        )
+        with urllib.request.urlopen(msg_req, context=ctx, timeout=15) as resp:
+            return True
+    except Exception as e:
+        log.error("[ERROR] Discord DM failed: %s", e)
+        return False
+
+
+def format_tokens(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    elif n >= 1_000:
+        return f"{n / 1_000:.0f}K"
+    return str(n)
+
+
+def format_duration(hours: float) -> str:
+    h = int(hours)
+    m = int((hours - h) * 60)
+    if h > 0:
+        return f"{h}h{m:02d}m"
+    return f"{m}m"
+
+
+def build_report(config: dict) -> str:
+    base_domain = config["api_domain"]
+    token = config["auth_token"]
+    now = datetime.now()
+
+    # Query yesterday's usage (00:00 - 23:59:59)
+    yesterday = now - timedelta(days=1)
+    start = yesterday.replace(hour=0, minute=0, second=0, microsecond=0)
+    end = yesterday.replace(hour=23, minute=59, second=59, microsecond=999)
+
+    fmt = lambda d: d.strftime("%Y-%m-%d %H:%M:%S")
+    params = f"?startTime={urllib.parse.quote(fmt(start))}&endTime={urllib.parse.quote(fmt(end))}"
+
+    # Fetch data
+    model_data = api_get(f"{base_domain}/api/monitor/usage/model-usage{params}", token)
+    tool_data = api_get(f"{base_domain}/api/monitor/usage/tool-usage{params}", token)
+    quota_data = api_get(f"{base_domain}/api/monitor/usage/quota/limit", token)
+
+    date_str = yesterday.strftime("%Y-%m-%d")
+
+    # --- Model usage ---
+    total_calls = model_data.get("totalUsage", {}).get("totalModelCallCount", 0)
+    total_tokens = model_data.get("totalUsage", {}).get("totalTokensUsage", 0)
+
+    model_lines = []
+    for m in model_data.get("totalUsage", {}).get("modelSummaryList", []):
+        name = m["modelName"]
+        tokens = m["totalTokens"]
+        pct = (tokens / total_tokens * 100) if total_tokens > 0 else 0
+        model_lines.append(f"  • {name}: {format_tokens(tokens)} tokens ({pct:.0f}%)")
+
+    # --- Peak hours ---
+    x_time = model_data.get("x_time", [])
+    tokens_usage = model_data.get("tokensUsage", [])
+    hourly = []
+    for t, u in zip(x_time, tokens_usage):
+        if u > 0:
+            hourly.append((t, u))
+    hourly.sort(key=lambda x: x[1], reverse=True)
+    peak_lines = []
+    for t, u in hourly[:3]:
+        hour = t.split(" ")[1] if " " in t else t
+        peak_lines.append(f"  • {hour} — {format_tokens(u)}")
+
+    # --- Tool usage ---
+    tool_total = tool_data.get("totalUsage", {})
+    search_count = tool_total.get("totalNetworkSearchCount", 0)
+    webread_count = tool_total.get("totalWebReadMcpCount", 0)
+    zread_count = tool_total.get("totalZreadMcpCount", 0)
+    tool_sum = search_count + webread_count + zread_count
+
+    # --- Quota ---
+    quota_lines = []
+    for item in quota_data.get("limits", []):
+        if item.get("type") == "TOKENS_LIMIT":
+            pct = item.get("percentage", 0)
+            reset_ts = item.get("nextResetTime")
+            if reset_ts:
+                reset_dt = datetime.fromtimestamp(reset_ts / 1000)
+                quota_lines.append(f"  • 5h Token 窗口: {pct}% (重置: {reset_dt.strftime('%H:%M')})")
+            else:
+                quota_lines.append(f"  • 5h Token 窗口: {pct}%")
+        elif item.get("type") == "TIME_LIMIT":
+            pct = item.get("percentage", 0)
+            curr = item.get("currentValue", 0)
+            total = item.get("usage", 0)
+            remain = item.get("remaining", total - curr)
+            details = item.get("usageDetails", [])
+            detail_str = " / ".join(f"{d['modelCode']}: {d['usage']}" for d in details)
+            quota_lines.append(f"  • MCP 月度: {pct}% ({curr}/{total}, 剩余 {remain})")
+            if detail_str:
+                quota_lines.append(f"    ({detail_str})")
+
+    level = quota_data.get("level", "?")
+
+    # --- Active hours ---
+    active_hours = len(hourly)
+    first_active = hourly[-1][0].split(" ")[1] if hourly else "—"
+    last_active = hourly[0][0].split(" ")[1] if hourly else "—"
+
+    # --- Build report ---
+    report = (
+        f"📊 **GLM 每日用量报告 — {date_str}**\n"
+        f"━━━━━━━━━━━━━━━━━━━━\n\n"
+        f"**总用量**\n"
+        f"  Tokens: {format_tokens(total_tokens)} | 调用: {total_calls} 次\n"
+        f"  活跃时段: {active_hours} 小时 ({first_active} ~ {last_active})\n\n"
+        f"**模型分布**\n"
+        + "\n".join(model_lines) + "\n\n"
+        f"**Peak 3 时段**\n"
+        + "\n".join(peak_lines) + "\n\n"
+    )
+
+    if tool_sum > 0:
+        report += (
+            f"**MCP 工具**\n"
+            f"  search: {search_count} | web-read: {webread_count} | zread: {zread_count}\n\n"
+        )
+
+    report += (
+        f"**当前配额 (Plan: {level})**\n"
+        + "\n".join(quota_lines)
+    )
+
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GLM Daily Usage Summary")
+    parser.add_argument("--dry-run", action="store_true", help="Print report without sending DM")
+    parser.add_argument("--send-only", action="store_true", help="Send last cached report")
+    args = parser.parse_args()
+
+    setup_logging()
+
+    log.info("=" * 50)
+    log.info("[%s] Daily Summary started", datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+    log.info("=" * 50)
+
+    if args.send_only:
+        try:
+            with open(CACHE_PATH, "r") as f:
+                report = json.load(f)["report"]
+        except (FileNotFoundError, json.JSONDecodeError, KeyError):
+            log.error("[ERROR] No cached report found. Run without --send-only first.")
+            sys.exit(1)
+    else:
+        glm_config = load_key_value_file(GLM_CONFIG_PATH)
+        glm_config["auth_token"] = os.environ.get("ANTHROPIC_AUTH_TOKEN", glm_config.get("ANTHROPIC_AUTH_TOKEN", ""))
+        glm_config["base_url"] = os.environ.get("ANTHROPIC_BASE_URL", glm_config.get("ANTHROPIC_BASE_URL", ""))
+
+        if not glm_config["auth_token"] or not glm_config["base_url"]:
+            log.error("[ERROR] GLM config incomplete")
+            sys.exit(1)
+
+        parsed = urllib.parse.urlparse(glm_config["base_url"])
+        glm_config["api_domain"] = f"{parsed.scheme}://{parsed.netloc}"
+
+        log.info("Building daily usage report...")
+        report = build_report(glm_config)
+
+        # Cache it
+        with open(CACHE_PATH, "w") as f:
+            json.dump({"report": report, "generated_at": datetime.now().isoformat()}, f, indent=2)
+
+    log.info(report)
+
+    if args.dry_run:
+        log.info("[DRY RUN] Not sending DM.")
+        return
+
+    # Send DM
+    dc = load_key_value_file(DISCORD_CONFIG_PATH)
+    dc_token = dc.get("DISCORD_BOT_TOKEN")
+    dc_user = dc.get("DISCORD_ALLOWED_USERS")
+
+    if not dc_token or not dc_user:
+        log.error("[ERROR] Discord config missing, cannot send DM")
+        sys.exit(1)
+
+    if send_discord_dm(dc_token, dc_user, report):
+        log.info("✅ Daily summary sent via Discord DM!")
+    else:
+        log.error("❌ Failed to send DM")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/glm-plan-usage/scripts/weekly-summary.py
+++ b/plugins/glm-plan-usage/scripts/weekly-summary.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""
+GLM Weekly Trend Report — queries two weeks of usage and sends a Discord DM
+with week-over-week comparison. Designed to run as a cron job (zero Hermes token cost).
+
+Usage:
+    python3 weekly-summary.py                 # Full run (query + send DM)
+    python3 weekly-summary.py --dry-run       # Print report without sending DM
+"""
+
+import json
+import logging
+import os
+import sys
+import time
+import ssl
+import argparse
+import urllib.request
+import urllib.parse
+from datetime import datetime, timedelta
+
+# Force Asia/Shanghai
+os.environ["TZ"] = "Asia/Shanghai"
+time.tzset()
+
+# --- Config ---
+GLM_CONFIG_PATH = os.path.expanduser("~/.glm-config")
+DISCORD_CONFIG_PATH = os.path.expanduser("~/.discord-config")
+LOG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
+LOG_FILE = os.path.join(LOG_DIR, "weekly-summary.log")
+
+log = logging.getLogger("weekly-summary")
+
+
+def setup_logging():
+    """Configure logging to both file and stdout."""
+    os.makedirs(LOG_DIR, exist_ok=True)
+    log.setLevel(logging.DEBUG)
+
+    fh = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    fh.setLevel(logging.DEBUG)
+    fh.setFormatter(logging.Formatter("%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"))
+
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setLevel(logging.INFO)
+    sh.setFormatter(logging.Formatter("%(asctime)s %(message)s", datefmt="%H:%M:%S"))
+
+    log.addHandler(fh)
+    log.addHandler(sh)
+
+
+def load_key_value_file(path: str) -> dict:
+    config = {}
+    try:
+        with open(path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                eq = line.find("=")
+                if eq == -1:
+                    continue
+                config[line[:eq].strip()] = line[eq + 1:].strip()
+    except FileNotFoundError:
+        log.error("[ERROR] Config file not found: %s", path)
+        sys.exit(1)
+    return config
+
+
+def api_get(url: str, auth_token: str) -> dict:
+    ctx = ssl.create_default_context()
+    req = urllib.request.Request(url, headers={
+        "Authorization": auth_token,
+        "Accept-Language": "en-US,en",
+        "Content-Type": "application/json",
+        "User-Agent": "GLM-WeeklySummary/1.0",
+    })
+    with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+        data = json.loads(resp.read().decode())
+        return data.get("data", data)
+
+
+def send_discord_dm(bot_token: str, user_id: str, messages: list[str]) -> bool:
+    """Send one or more DM messages (split if too long for Discord 2000 char limit)."""
+    ctx = ssl.create_default_context()
+    headers = {
+        "Authorization": f"Bot {bot_token}",
+        "Content-Type": "application/json",
+        "User-Agent": "GLM-WeeklySummary/1.0",
+    }
+    try:
+        # Create DM channel
+        dm_payload = json.dumps({"recipient_id": user_id}).encode()
+        dm_req = urllib.request.Request(
+            "https://discord.com/api/v10/users/@me/channels",
+            data=dm_payload, headers=headers, method="POST",
+        )
+        with urllib.request.urlopen(dm_req, context=ctx, timeout=15) as resp:
+            channel_id = json.loads(resp.read().decode())["id"]
+
+        for msg in messages:
+            msg_payload = json.dumps({"content": msg}).encode()
+            msg_req = urllib.request.Request(
+                f"https://discord.com/api/v10/channels/{channel_id}/messages",
+                data=msg_payload, headers=headers, method="POST",
+            )
+            with urllib.request.urlopen(msg_req, context=ctx, timeout=15) as resp:
+                pass
+        log.info("[DISCORD] %d DM message(s) sent to %s", len(messages), user_id)
+        return True
+    except Exception as e:
+        log.error("[ERROR] Discord DM failed: %s", e)
+        return False
+
+
+def format_tokens(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    elif n >= 1_000:
+        return f"{n / 1_000:.0f}K"
+    return str(n)
+
+
+def pct_change(curr: float, prev: float) -> str:
+    if prev == 0:
+        return "🆕" if curr > 0 else "—"
+    change = (curr - prev) / prev * 100
+    if abs(change) < 1:
+        return "→ 0%"
+    if change > 0:
+        return f"↑ {change:.0f}%"
+    return f"↓ {abs(change):.0f}%"
+
+
+def get_week_range(reference_date: datetime = None) -> tuple[datetime, datetime, int, int]:
+    """Get last week's Monday 00:00 to Sunday 23:59:59 and ISO week number."""
+    if reference_date is None:
+        reference_date = datetime.now()
+
+    # Find last Monday (start of last week)
+    today_weekday = reference_date.weekday()  # 0=Monday
+    days_since_monday = today_weekday
+    this_monday = reference_date - timedelta(days=days_since_monday)
+    this_monday = this_monday.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    last_monday = this_monday - timedelta(days=7)
+    last_sunday_end = this_monday - timedelta(seconds=1)
+
+    iso = last_monday.isocalendar()
+    week_num = iso[1]
+    year = iso[0]
+
+    return last_monday, last_sunday_end, week_num, year
+
+
+def get_prev_week_range(last_monday: datetime) -> tuple[datetime, datetime]:
+    """Get the week before last week."""
+    prev_monday = last_monday - timedelta(days=7)
+    prev_sunday_end = last_monday - timedelta(seconds=1)
+    return prev_monday, prev_sunday_end
+
+
+def query_week(config: dict, start: datetime, end: datetime) -> dict:
+    """Query model + tool usage for a time range."""
+    fmt = lambda d: d.strftime("%Y-%m-%d %H:%M:%S")
+    params = f"?startTime={urllib.parse.quote(fmt(start))}&endTime={urllib.parse.quote(fmt(end))}"
+
+    model_data = api_get(f"{config['api_domain']}/api/monitor/usage/model-usage{params}", config["auth_token"])
+    tool_data = api_get(f"{config['api_domain']}/api/monitor/usage/tool-usage{params}", config["auth_token"])
+
+    return {"model": model_data, "tool": tool_data}
+
+
+def aggregate_daily(model_data: dict) -> dict:
+    """Aggregate hourly data by day."""
+    x_time = model_data.get("x_time", [])
+    tokens_usage = model_data.get("tokensUsage", [])
+    call_counts = model_data.get("modelCallCount", [])
+
+    daily = {}
+    for t, tok, calls in zip(x_time, tokens_usage, call_counts):
+        date_str = t.split(" ")[0]  # "2026-05-05"
+        short = date_str[5:]  # "05-05"
+        weekday_idx = datetime.strptime(date_str, "%Y-%m-%d").weekday()
+        weekday_names = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"]
+        if short not in daily:
+            daily[short] = {"date": short, "weekday": weekday_names[weekday_idx], "tokens": 0, "calls": 0}
+        daily[short]["tokens"] += tok
+        daily[short]["calls"] += calls
+    return daily
+
+
+def aggregate_models(model_data: dict) -> dict:
+    """Aggregate by model."""
+    result = {}
+    total = model_data.get("totalUsage", {}).get("totalTokensUsage", 0)
+    for m in model_data.get("totalUsage", {}).get("modelSummaryList", []):
+        name = m["modelName"]
+        tokens = m["totalTokens"]
+        pct = (tokens / total * 100) if total > 0 else 0
+        result[name] = {"tokens": tokens, "pct": pct}
+    return result
+
+
+def aggregate_tools(tool_data: dict) -> dict:
+    """Aggregate tool usage."""
+    total = tool_data.get("totalUsage", {})
+    return {
+        "search": total.get("totalNetworkSearchCount", 0),
+        "web-read": total.get("totalWebReadMcpCount", 0),
+        "zread": total.get("totalZreadMcpCount", 0),
+        "search-mcp": total.get("totalSearchMcpCount", 0),
+    }
+
+
+def find_peak_hours(model_data: dict, top_n: int = 5) -> list[tuple[str, str, int]]:
+    """Find top N peak hours."""
+    x_time = model_data.get("x_time", [])
+    tokens_usage = model_data.get("tokensUsage", [])
+    hourly = [(t, tok) for t, tok in zip(x_time, tokens_usage) if tok > 0]
+    hourly.sort(key=lambda x: x[1], reverse=True)
+    result = []
+    for t, tok in hourly[:top_n]:
+        parts = t.split(" ")
+        date_short = parts[0][5:] if len(parts) > 1 else ""
+        hour = parts[1][:5] if len(parts) > 1 else t
+        result.append((date_short, hour, tok))
+    return result
+
+
+def bar_chart(daily: dict, width: int = 10) -> list[str]:
+    """Generate ASCII bar chart for daily usage."""
+    if not daily:
+        return ["  (无数据)"]
+
+    sorted_days = sorted(daily.items())
+    max_val = max(d["tokens"] for d in daily.values())
+    lines = []
+
+    max_tokens = max_val
+    min_tokens = min(d["tokens"] for d in daily.values())
+    annotations = {}
+    if max_tokens > 0:
+        for k, v in daily.items():
+            if v["tokens"] == max_tokens:
+                annotations[k] = " ← 最高"
+            elif min_tokens == max_tokens:
+                pass
+            elif v["tokens"] == min_tokens:
+                annotations[k] = " ← 最低"
+
+    for day, data in sorted_days:
+        ratio = data["tokens"] / max_val if max_val > 0 else 0
+        filled = round(ratio * width)
+        bar = "█" * filled + "░" * (width - filled)
+        ann = annotations.get(day, "")
+        lines.append(f"  {data['weekday']} {day}  {bar}  {format_tokens(data['tokens'])}  {data['calls']}次{ann}")
+
+    return lines
+
+
+def build_report(config: dict) -> list[str]:
+    """Build the weekly trend report. Returns list of messages (split for Discord 2000 char limit)."""
+    now = datetime.now()
+    last_monday, last_sunday_end, week_num, year = get_week_range(now)
+    prev_monday, prev_sunday_end = get_prev_week_range(last_monday)
+
+    log.info("Querying last week: %s ~ %s", last_monday.strftime("%Y-%m-%d"), last_sunday_end.strftime("%Y-%m-%d"))
+    log.info("Querying prev week: %s ~ %s", prev_monday.strftime("%Y-%m-%d"), prev_sunday_end.strftime("%Y-%m-%d"))
+
+    # Query both weeks
+    last_week = query_week(config, last_monday, last_sunday_end)
+    prev_week = query_week(config, prev_monday, prev_sunday_end)
+
+    # Query current quota
+    quota_data = api_get(f"{config['api_domain']}/api/monitor/usage/quota/limit", config["auth_token"])
+
+    # Aggregate
+    lw_daily = aggregate_daily(last_week["model"])
+    pw_daily = aggregate_daily(prev_week["model"])
+
+    lw_models = aggregate_models(last_week["model"])
+    pw_models = aggregate_models(prev_week["model"])
+
+    lw_tools = aggregate_tools(last_week["tool"])
+    pw_tools = aggregate_tools(prev_week["tool"])
+
+    lw_total_tokens = sum(d["tokens"] for d in lw_daily.values())
+    lw_total_calls = sum(d["calls"] for d in lw_daily.values())
+    pw_total_tokens = sum(d["tokens"] for d in pw_daily.values())
+    pw_total_calls = sum(d["calls"] for d in pw_daily.values())
+
+    # --- Build report ---
+    date_range = f"{last_monday.strftime('%m.%d')} - {last_sunday_end.strftime('%m.%d')}"
+
+    lines = []
+    lines.append(f"📈 **GLM 每周趋势报告 — {year}-W{week_num:02d} ({date_range})**")
+    lines.append("━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    lines.append("")
+
+    # Overview
+    lines.append("**本周概览**")
+    lines.append(f"  Tokens: {format_tokens(lw_total_tokens)} | 调用: {lw_total_calls:,} 次")
+    lines.append(f"  vs 上周: {pct_change(lw_total_tokens, pw_total_tokens)} tokens, {pct_change(lw_total_calls, pw_total_calls)} 调用")
+    lines.append("")
+
+    # Daily distribution
+    lines.append("**每日分布**")
+    lines.extend(bar_chart(lw_daily))
+    lines.append("")
+
+    # Model distribution
+    lines.append("**模型分布**")
+    for name in sorted(lw_models.keys(), key=lambda n: lw_models[n]["tokens"], reverse=True):
+        m = lw_models[name]
+        prev_tok = pw_models.get(name, {}).get("tokens", 0)
+        lines.append(f"  • {name}: {format_tokens(m['tokens'])} ({m['pct']:.0f}%)  {pct_change(m['tokens'], prev_tok)}")
+    lines.append("")
+
+    # Peak hours
+    peaks = find_peak_hours(last_week["model"], 5)
+    if peaks:
+        lines.append("**峰值时段 Top 5**")
+        for date_short, hour, tok in peaks:
+            lines.append(f"  • {date_short} {hour} — {format_tokens(tok)}")
+        lines.append("")
+
+    # MCP tools
+    lw_tool_sum = sum(lw_tools.values())
+    pw_tool_sum = sum(pw_tools.values())
+    if lw_tool_sum > 0 or pw_tool_sum > 0:
+        tool_details = [f"{k}: {v}" for k, v in lw_tools.items() if v > 0]
+        lines.append("**MCP 工具**")
+        lines.append(f"  {' | '.join(tool_details)}")
+        lines.append(f"  vs 上周: {pct_change(lw_tool_sum, pw_tool_sum)}")
+        lines.append("")
+
+    # Quota
+    level = quota_data.get("level", "?")
+    lines.append(f"**当前配额 (Plan: {level})**")
+    for item in quota_data.get("limits", []):
+        if item.get("type") == "TOKENS_LIMIT":
+            pct = item.get("percentage", 0)
+            reset_ts = item.get("nextResetTime")
+            if reset_ts:
+                reset_dt = datetime.fromtimestamp(reset_ts / 1000)
+                lines.append(f"  • 5h Token 窗口: {pct}% (重置: {reset_dt.strftime('%m.%d %H:%M')})")
+            else:
+                lines.append(f"  • 5h Token 窗口: {pct}%")
+        elif item.get("type") == "TIME_LIMIT":
+            pct = item.get("percentage", 0)
+            curr = item.get("currentValue", 0)
+            total = item.get("usage", 0)
+            remain = item.get("remaining", total - curr)
+            lines.append(f"  • MCP 月度: {pct}% ({curr}/{total}, 剩余 {remain})")
+
+    # Split into messages (Discord 2000 char limit)
+    full_text = "\n".join(lines)
+    messages = []
+    if len(full_text) <= 2000:
+        messages.append(full_text)
+    else:
+        # Split at section boundaries
+        current_msg = []
+        current_len = 0
+        for line in lines:
+            line_len = len(line) + 1  # +1 for newline
+            if current_len + line_len > 1950 and current_msg:
+                messages.append("\n".join(current_msg))
+                current_msg = []
+                current_len = 0
+            current_msg.append(line)
+            current_len += line_len
+        if current_msg:
+            messages.append("\n".join(current_msg))
+
+    return messages
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GLM Weekly Trend Report")
+    parser.add_argument("--dry-run", action="store_true", help="Print report without sending DM")
+    args = parser.parse_args()
+
+    setup_logging()
+
+    log.info("=" * 50)
+    log.info("[%s] Weekly Summary started", datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+    log.info("=" * 50)
+
+    glm_config = load_key_value_file(GLM_CONFIG_PATH)
+    glm_config["auth_token"] = os.environ.get("ANTHROPIC_AUTH_TOKEN", glm_config.get("ANTHROPIC_AUTH_TOKEN", ""))
+    glm_config["base_url"] = os.environ.get("ANTHROPIC_BASE_URL", glm_config.get("ANTHROPIC_BASE_URL", ""))
+
+    if not glm_config["auth_token"] or not glm_config["base_url"]:
+        log.error("[ERROR] GLM config incomplete")
+        sys.exit(1)
+
+    parsed = urllib.parse.urlparse(glm_config["base_url"])
+    glm_config["api_domain"] = f"{parsed.scheme}://{parsed.netloc}"
+
+    log.info("Building weekly trend report...")
+    messages = build_report(glm_config)
+
+    for i, msg in enumerate(messages):
+        log.info("=" * 40)
+        log.info("Message %d/%d (%d chars)", i + 1, len(messages), len(msg))
+        log.info("=" * 40)
+        log.info(msg)
+
+    if args.dry_run:
+        log.info("[DRY RUN] Not sending DM.")
+        return
+
+    # Send DM
+    dc = load_key_value_file(DISCORD_CONFIG_PATH)
+    dc_token = dc.get("DISCORD_BOT_TOKEN")
+    dc_user = dc.get("DISCORD_ALLOWED_USERS")
+
+    if not dc_token or not dc_user:
+        log.error("[ERROR] Discord config missing, cannot send DM")
+        sys.exit(1)
+
+    if send_discord_dm(dc_token, dc_user, messages):
+        log.info("✅ Weekly summary sent via Discord DM!")
+    else:
+        log.error("❌ Failed to send DM")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/glm-plan-usage/scripts/window-manager.py
+++ b/plugins/glm-plan-usage/scripts/window-manager.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+"""
+GLM Coding Plan Window Manager
+
+Manages the 5-hour token window refresh cycle for Zhipu GLM Coding Plan.
+Runs as a long-lived background process, self-scheduling the next refresh.
+
+Time slots (active hours):
+  06:00 - 11:00  Window 1 (covers morning peak)
+  11:00 - 16:00  Window 2 (covers midday peak)
+  16:00 - 21:00  Window 3 (covers afternoon peak)
+  21:00 - 02:00  Window 4 (late night tail)
+  02:00 - 06:00  SILENT — no refresh, leave as buffer
+
+Usage:
+    python3 window-manager.py [--once] [--config CONFIG_PATH]
+
+Options:
+    --once       Run once and exit (useful for testing or manual trigger)
+    --config     Path to config file (default: ~/.glm-config)
+"""
+
+import json
+import logging
+import os
+import sys
+import time
+import ssl
+import argparse
+import urllib.request
+import urllib.parse
+import urllib.error
+from datetime import datetime, timedelta, timezone
+
+# --- Timezone ---
+# All API responses use Beijing time; force Asia/Shanghai throughout.
+os.environ["TZ"] = "Asia/Shanghai"
+time.tzset()
+TZ_SHANGHAI = timezone(timedelta(hours=8))
+
+# --- Config ---
+
+DEFAULT_CONFIG_PATH = os.path.expanduser("~/.glm-config")
+DISCORD_CONFIG_PATH = os.path.expanduser("~/.discord-config")
+STATE_FILE_PATH = os.path.expanduser("~/.glm-window-state.json")
+LOG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
+LOG_FILE = os.path.join(LOG_DIR, "window-manager.log")
+
+log = logging.getLogger("window-manager")
+
+# Time slots: (refresh_hour, label)
+SLOTS = [
+    (6,  "Morning  [06:00-11:00]"),
+    (11, "Midday   [11:00-16:00]"),
+    (16, "Afternoon[16:00-21:00]"),
+    (21, "Night    [21:00-02:00]"),
+]
+# Silent period: 02:00 - 06:00, no refresh
+
+
+def setup_logging():
+    """Configure logging to both file and stdout."""
+    os.makedirs(LOG_DIR, exist_ok=True)
+    log.setLevel(logging.DEBUG)
+
+    # File handler — append, keep detailed logs
+    fh = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    fh.setLevel(logging.DEBUG)
+    fh.setFormatter(logging.Formatter("%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"))
+
+    # Stdout handler
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setLevel(logging.INFO)
+    sh.setFormatter(logging.Formatter("%(asctime)s %(message)s", datefmt="%H:%M:%S"))
+
+    log.addHandler(fh)
+    log.addHandler(sh)
+
+
+def load_config(config_path: str) -> dict:
+    """Load API credentials from config file."""
+    config = {}
+    try:
+        with open(config_path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                eq = line.find("=")
+                if eq == -1:
+                    continue
+                key = line[:eq].strip()
+                value = line[eq + 1 :].strip()
+                config[key] = value
+    except FileNotFoundError:
+        log.error("[ERROR] Config file not found: %s", config_path)
+        sys.exit(1)
+
+    # Env vars override config file
+    config["auth_token"] = os.environ.get("ANTHROPIC_AUTH_TOKEN", config.get("ANTHROPIC_AUTH_TOKEN", ""))
+    config["base_url"] = os.environ.get("ANTHROPIC_BASE_URL", config.get("ANTHROPIC_BASE_URL", ""))
+
+    if not config["auth_token"]:
+        log.error("[ERROR] ANTHROPIC_AUTH_TOKEN not set")
+        sys.exit(1)
+    if not config["base_url"]:
+        log.error("[ERROR] ANTHROPIC_BASE_URL not set")
+        sys.exit(1)
+
+    # Determine platform
+    if "api.z.ai" in config["base_url"]:
+        config["platform"] = "ZAI"
+    elif "open.bigmodel.cn" in config["base_url"] or "dev.bigmodel.cn" in config["base_url"]:
+        config["platform"] = "ZHIPU"
+    else:
+        log.error("[ERROR] Unrecognized base URL: %s", config['base_url'])
+        sys.exit(1)
+
+    # Build API domain
+    parsed = urllib.parse.urlparse(config["base_url"])
+    config["api_domain"] = f"{parsed.scheme}://{parsed.netloc}"
+
+    return config
+
+
+def load_state() -> dict:
+    """Load window state from file."""
+    try:
+        with open(STATE_FILE_PATH, "r") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def save_state(state: dict):
+    """Save window state to file."""
+    with open(STATE_FILE_PATH, "w") as f:
+        json.dump(state, f, indent=2, default=str)
+        f.write("\n")
+
+
+def api_request(url: str, auth_token: str) -> dict:
+    """Make an authenticated GET request to the API."""
+    ctx = ssl.create_default_context()
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": auth_token,
+            "Accept-Language": "en-US,en",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+        return json.loads(resp.read().decode())
+
+
+def load_discord_config() -> dict:
+    """Load Discord bot config for DM notifications."""
+    config = {}
+    try:
+        with open(DISCORD_CONFIG_PATH, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                eq = line.find("=")
+                if eq == -1:
+                    continue
+                key = line[:eq].strip()
+                value = line[eq + 1:].strip()
+                config[key] = value
+    except FileNotFoundError:
+        log.warning("[WARN] Discord config not found: %s, DM notifications disabled", DISCORD_CONFIG_PATH)
+        return {}
+    return config
+
+
+def send_discord_dm(bot_token: str, user_id: str, message: str) -> bool:
+    """Send a DM via Discord Bot API."""
+    ctx = ssl.create_default_context()
+    headers = {
+        "Authorization": f"Bot {bot_token}",
+        "Content-Type": "application/json",
+        "User-Agent": "GLM-WindowManager/1.0",
+    }
+    try:
+        # Create DM channel
+        dm_payload = json.dumps({"recipient_id": user_id}).encode()
+        dm_req = urllib.request.Request(
+            "https://discord.com/api/v10/users/@me/channels",
+            data=dm_payload,
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(dm_req, context=ctx, timeout=15) as resp:
+            channel_data = json.loads(resp.read().decode())
+            channel_id = channel_data["id"]
+
+        # Send message
+        msg_payload = json.dumps({"content": message}).encode()
+        msg_req = urllib.request.Request(
+            f"https://discord.com/api/v10/channels/{channel_id}/messages",
+            data=msg_payload,
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(msg_req, context=ctx, timeout=15) as resp:
+            log.info("[DISCORD] DM sent to %s", user_id)
+            return True
+    except Exception as e:
+        log.error("[DISCORD] Failed to send DM: %s", e)
+        return False
+
+
+def query_quota(config: dict) -> dict:
+    """Query current quota/limit status."""
+    url = f"{config['api_domain']}/api/monitor/usage/quota/limit"
+    data = api_request(url, config["auth_token"])
+    return data.get("data", data)
+
+
+def query_model_usage(config: dict, start_time: str, end_time: str) -> dict:
+    """Query model usage for a time range."""
+    params = f"?startTime={urllib.parse.quote(start_time)}&endTime={urllib.parse.quote(end_time)}"
+    url = f"{config['api_domain']}/api/monitor/usage/model-usage{params}"
+    data = api_request(url, config["auth_token"])
+    return data.get("data", data)
+
+
+def parse_quota_limits(quota_data: dict) -> dict:
+    """Parse quota limits into a readable dict, preserving all API fields."""
+    result = {"level": quota_data.get("level", "unknown"), "limits": {}}
+    for item in quota_data.get("limits", []):
+        limit_type = item.get("type", "")
+        if limit_type == "TOKENS_LIMIT":
+            # nextResetTime is authoritative — use it instead of manual calculation
+            reset_ts = item.get("nextResetTime")
+            reset_dt = datetime.fromtimestamp(reset_ts / 1000) if reset_ts else None
+            result["limits"]["token_5h"] = {
+                "type": item.get("type"),
+                "unit": item.get("unit"),
+                "number": item.get("number"),
+                "percentage": item.get("percentage", 0),
+                "next_reset_time": reset_ts,
+                "next_reset_dt": format_dt(reset_dt) if reset_dt else None,
+            }
+        elif limit_type == "TIME_LIMIT":
+            reset_ts = item.get("nextResetTime")
+            reset_dt = datetime.fromtimestamp(reset_ts / 1000) if reset_ts else None
+            result["limits"]["mcp_monthly"] = {
+                "type": item.get("type"),
+                "unit": item.get("unit"),
+                "number": item.get("number"),
+                "percentage": item.get("percentage", 0),
+                "current_usage": item.get("currentValue", 0),
+                "total": item.get("usage", 0),
+                "remaining": item.get("remaining"),
+                "next_reset_time": reset_ts,
+                "next_reset_dt": format_dt(reset_dt) if reset_dt else None,
+                "details": item.get("usageDetails", []),
+            }
+    return result
+
+
+def send_refresh_request(config: dict) -> bool:
+    """Send a minimal chat completion request to trigger a new window."""
+    # Use the full base_url path (e.g. /api/coding/paas/v4) to hit the coding plan endpoint
+    url = f"{config['base_url']}/chat/completions"
+    payload = json.dumps({
+        "model": "glm-4-flash",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 1,
+    }).encode()
+
+    ctx = ssl.create_default_context()
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "Authorization": config["auth_token"],
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+            data = json.loads(resp.read().decode())
+            log.info("[REFRESH] Request sent, response OK")
+            return True
+    except urllib.error.HTTPError as e:
+        body = e.read().decode() if e.fp else ""
+        log.error("[REFRESH] HTTP %d: %s", e.code, body[:200])
+        return False
+    except Exception as e:
+        log.error("[REFRESH] Error: %s", e)
+        return False
+
+
+def format_dt(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def format_duration(seconds: float) -> str:
+    if seconds < 0:
+        return "expired"
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    if hours > 0:
+        return f"{hours}h {minutes}m"
+    return f"{minutes}m"
+
+
+def get_current_slot(now_hour: int) -> dict:
+    """
+    Determine which time slot we're in and the next action.
+
+    Returns:
+        dict with:
+          slot_index: which slot (0-3), -1 if silent period
+          slot_label: human readable label
+          refresh_hour: hour when this slot's refresh should happen
+          next_slot_hour: hour of the next slot's refresh
+          is_silent: True if in silent period (02:00-06:00)
+    """
+    if now_hour < 2:
+        # 00:00-01:59 → still in the night slot, next is 06:00
+        return {
+            "slot_index": 3,
+            "slot_label": "Night    [21:00-02:00]",
+            "refresh_hour": 21,
+            "next_slot_hour": 6,
+            "is_silent": False,
+            "next_is_tomorrow": True,
+        }
+    elif now_hour < 6:
+        # 02:00-05:59 → SILENT period
+        return {
+            "slot_index": -1,
+            "slot_label": "SILENT   [02:00-06:00]",
+            "refresh_hour": None,
+            "next_slot_hour": 6,
+            "is_silent": True,
+            "next_is_tomorrow": False,
+        }
+    elif now_hour < 11:
+        return {
+            "slot_index": 0,
+            "slot_label": "Morning  [06:00-11:00]",
+            "refresh_hour": 6,
+            "next_slot_hour": 11,
+            "is_silent": False,
+            "next_is_tomorrow": False,
+        }
+    elif now_hour < 16:
+        return {
+            "slot_index": 1,
+            "slot_label": "Midday   [11:00-16:00]",
+            "refresh_hour": 11,
+            "next_slot_hour": 16,
+            "is_silent": False,
+            "next_is_tomorrow": False,
+        }
+    elif now_hour < 21:
+        return {
+            "slot_index": 2,
+            "slot_label": "Afternoon[16:00-21:00]",
+            "refresh_hour": 16,
+            "next_slot_hour": 21,
+            "is_silent": False,
+            "next_is_tomorrow": False,
+        }
+    else:
+        # 21:00-23:59
+        return {
+            "slot_index": 3,
+            "slot_label": "Night    [21:00-02:00]",
+            "refresh_hour": 21,
+            "next_slot_hour": 6,
+            "is_silent": False,
+            "next_is_tomorrow": True,
+        }
+
+
+def target_time_for_slot(now: datetime, hour: int) -> datetime:
+    """Get the next occurrence of a specific hour."""
+    target = now.replace(hour=hour, minute=0, second=0, microsecond=0)
+    if target <= now:
+        target += timedelta(days=1)
+    return target
+
+
+def run_once(config: dict) -> dict:
+    """
+    Run one check cycle. Returns action dict with scheduling info.
+    """
+    now = datetime.now()
+    state = load_state()
+    log.info("=" * 60)
+    log.info("[%s] Window Manager Check", format_dt(now))
+    log.info("=" * 60)
+
+    # 1. Query current quota
+    log.info("Querying quota status...")
+    try:
+        quota_data = query_quota(config)
+        quota = parse_quota_limits(quota_data)
+    except Exception as e:
+        log.error("[ERROR] Failed to query quota: %s", e)
+        return {"action": "retry_later", "retry_minutes": 5}
+
+    token_info = quota["limits"].get("token_5h", {})
+    token_pct = token_info.get("percentage", -1)
+    api_reset_dt = token_info.get("next_reset_dt")  # from API, authoritative
+    level = quota.get("level", "unknown")
+    log.info("Plan: %s | Token window: %s%%", level, token_pct)
+    if api_reset_dt:
+        log.info("API nextResetTime: %s", api_reset_dt)
+
+    # 2. Determine current time slot
+    slot = get_current_slot(now.hour)
+    log.info("Slot: %s", slot['slot_label'])
+
+    # 3. SILENT period (02:00-06:00)
+    if slot["is_silent"]:
+        next_morning = target_time_for_slot(now, 6)
+        wait = (next_morning - now).total_seconds()
+        log.info("[SILENT] Buffer period, skipping until 06:00")
+        log.info("💤 Sleeping %s...", format_duration(wait))
+        return {"action": "sleep", "seconds": wait}
+
+    # 4. Check if someone already opened a new window (usage ≤ 1%)
+    # A minimal refresh request itself consumes at least 1%, so this is the
+    # practical floor for detecting a freshly opened window.
+    # NOTE: 0% does NOT mean "window just created" — it only means "no tokens
+    # consumed in this window yet". The window might have been alive for hours.
+    # We only claim if API confirms it's truly fresh (no nextResetTime or far future).
+    if token_pct == 0 and not api_reset_dt:
+        # No nextResetTime + 0% = genuinely fresh window, safe to claim
+        log.info("[ACTION] Token 0%% and no nextResetTime — sending request to claim new window")
+        success = send_refresh_request(config)
+        if success:
+            log.info("[OK] Window claimed successfully")
+        else:
+            log.warning("[WARN] Failed to claim window, will treat as active anyway")
+    elif token_pct == 0 and api_reset_dt:
+        # 0% but has nextResetTime — window is old but unused, don't waste a claim
+        log.info("[INFO] Token 0%% but nextResetTime=%s — window already active, skipping claim", api_reset_dt)
+    if token_pct >= 0 and token_pct <= 1:
+        log.info("[INFO] Token usage is %s%% — new window already active", token_pct)
+        # Still sleep to next slot boundary
+        next_target = target_time_for_slot(now, slot["next_slot_hour"])
+        wait = (next_target - now).total_seconds()
+        new_state = {
+            "window_start": format_dt(now),
+            "expected_expiry": format_dt(now + timedelta(hours=5)),
+            "last_refresh": format_dt(now),
+            "refresh_trigger": "detected_external" if token_pct > 0 else "window_manager",
+            "current_slot": slot["slot_label"],
+            "plan_level": level,
+        }
+        save_state(new_state)
+        log.info("💤 Sleeping to next slot at %s (%s)...", format_dt(next_target), format_duration(wait))
+
+        # Send Discord DM notification
+        dc = load_discord_config()
+        dc_token = dc.get("DISCORD_BOT_TOKEN")
+        dc_user = dc.get("DISCORD_ALLOWED_USERS")
+        if dc_token and dc_user:
+            emoji = "🔄" if token_pct == 0 else "✅"
+            action = "Refreshed" if token_pct == 0 else "Active"
+            msg = (
+                f"{emoji} **GLM Window {action}**\n"
+                f"Slot: {slot['slot_label']}\n"
+                f"Token: {token_pct}%\n"
+                f"Plan: {level}\n"
+                f"⏰ {format_dt(now)}"
+            )
+            send_discord_dm(dc_token, dc_user, msg)
+
+        return {"action": "sleep", "seconds": wait}
+
+    # 5. Check if old window is still alive
+    state_expiry = state.get("expected_expiry")
+    state_slot = state.get("current_slot")
+
+    if state_slot == slot["slot_label"]:
+        # This slot was already refreshed, sleep to next slot
+        next_target = target_time_for_slot(now, slot["next_slot_hour"])
+        wait = (next_target - now).total_seconds()
+        log.info("Slot already refreshed, window until %s", state_expiry)
+        log.info("💤 Sleeping to next slot at %s (%s)...", format_dt(next_target), format_duration(wait))
+        return {"action": "sleep", "seconds": wait}
+
+    # 6. New slot, but old window might still be alive — wait for it to expire
+    # Prefer API's nextResetTime (authoritative), fall back to state file
+    window_expiry_str = api_reset_dt or state_expiry
+    if window_expiry_str and token_pct > 0:
+        try:
+            expiry_dt = datetime.strptime(window_expiry_str, "%Y-%m-%d %H:%M:%S")
+            source = "API" if api_reset_dt else "state file"
+            remaining = (expiry_dt - now).total_seconds()
+            if remaining > 0:
+                # Old window still alive, wait for it to expire
+                # Add a small grace (30s) to ensure it's truly expired
+                wait = remaining + 30
+                log.info("[WAIT] Old window alive until %s (%s left, src: %s)", window_expiry_str, format_duration(remaining), source)
+                log.info("💤 Sleeping %s until window expires, then will refresh...", format_duration(wait))
+                return {"action": "wait_then_refresh", "seconds": wait}
+        except ValueError:
+            pass
+
+    # 7. Old window expired or no state — refresh now
+    log.info("[ACTION] Refreshing for slot: %s", slot['slot_label'])
+    success = send_refresh_request(config)
+
+    if success:
+        new_expiry = now + timedelta(hours=5)
+        new_state = {
+            "window_start": format_dt(now),
+            "expected_expiry": format_dt(new_expiry),
+            "api_next_reset_dt": api_reset_dt,
+            "last_refresh": format_dt(now),
+            "refresh_trigger": "window_manager",
+            "current_slot": slot["slot_label"],
+            "plan_level": level,
+        }
+        save_state(new_state)
+        log.info("[OK] New window: %s → %s", format_dt(now), format_dt(new_expiry))
+
+        # Send Discord DM notification
+        dc = load_discord_config()
+        dc_token = dc.get("DISCORD_BOT_TOKEN")
+        dc_user = dc.get("DISCORD_ALLOWED_USERS")
+        if dc_token and dc_user:
+            msg = (
+                f"🔄 **GLM Window Refreshed**\n"
+                f"Slot: {slot['slot_label']}\n"
+                f"New window: {format_dt(now)} → {format_dt(new_expiry)}\n"
+                f"Plan: {level}"
+            )
+            send_discord_dm(dc_token, dc_user, msg)
+
+        # Sleep to next slot boundary
+        next_target = target_time_for_slot(now, slot["next_slot_hour"])
+        wait = (next_target - now).total_seconds()
+        log.info("💤 Sleeping to next slot at %s (%s)...", format_dt(next_target), format_duration(wait))
+        return {"action": "refreshed", "seconds": wait}
+    else:
+        log.error("[FAIL] Refresh failed, will retry in 3 minutes")
+        return {"action": "retry_later", "retry_minutes": 3}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GLM Coding Plan Window Manager")
+    parser.add_argument("--once", action="store_true", help="Run once and exit")
+    parser.add_argument("--config", default=DEFAULT_CONFIG_PATH, help="Path to config file")
+    args = parser.parse_args()
+
+    setup_logging()
+
+    log.info("GLM Window Manager starting...")
+    log.info("  Config: %s", args.config)
+    log.info("  State:  %s", STATE_FILE_PATH)
+    log.info("  Log:    %s", LOG_FILE)
+    log.info("  Slots:")
+    for h, label in SLOTS:
+        log.info("    %02d:00  %s", h, label)
+    log.info("    02:00-06:00  SILENT (buffer)")
+
+    config = load_config(args.config)
+    log.info("  Platform: %s", config['platform'])
+    log.info("  API: %s", config['base_url'])
+
+    if args.once:
+        result = run_once(config)
+        log.info("Result: %s", json.dumps(result, indent=2))
+        return
+
+    # Main loop
+    while True:
+        result = run_once(config)
+
+        if result["action"] in ("sleep", "refreshed", "wait_then_refresh"):
+            wait = result.get("seconds", 300)
+            time.sleep(max(wait, 30))
+
+        elif result["action"] == "retry_later":
+            wait = result.get("retry_minutes", 5) * 60
+            time.sleep(wait)
+
+if __name__ == "__main__":
+    main()

--- a/plugins/glm-plan-usage/skills/usage-query-skill/scripts/query-usage.mjs
+++ b/plugins/glm-plan-usage/skills/usage-query-skill/scripts/query-usage.mjs
@@ -1,33 +1,57 @@
 #!/usr/bin/env node
 
 /**
- * Usage query script.
- * Determines whether to call the Z.ai or ZHIPU endpoint based on ANTHROPIC_BASE_URL
- * and authenticates with ANTHROPIC_AUTH_TOKEN.
+ * Usage query script for GLM Coding Plan.
+ * Reads config from ~/.glm-config (no env vars needed).
+ *
+ * ~/.glm-config format:
+ *   ANTHROPIC_AUTH_TOKEN=***
+ *   ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthropic
  */
 
 import https from 'https';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 
-// Read environment variables
-const baseUrl = process.env.ANTHROPIC_BASE_URL || '';
-const authToken = process.env.ANTHROPIC_AUTH_TOKEN || '';
+// Force Asia/Shanghai timezone — all API responses use Beijing time.
+process.env.TZ = 'Asia/Shanghai';
 
-if (!authToken) {
-  console.error('Error: ANTHROPIC_AUTH_TOKEN is not set');
-  console.error('');
-  console.error('Set the environment variable and retry:');
-  console.error('  export ANTHROPIC_AUTH_TOKEN="your-token-here"');
+// Read config from ~/.glm-config
+const configPath = path.join(os.homedir(), '.glm-config');
+
+let authToken = '';
+let baseUrl = '';
+
+try {
+  const configContent = fs.readFileSync(configPath, 'utf-8');
+  for (const line of configContent.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex === -1) continue;
+    const key = trimmed.slice(0, eqIndex).trim();
+    const value = trimmed.slice(eqIndex + 1).trim();
+    if (key === 'ANTHROPIC_AUTH_TOKEN') authToken = value;
+    if (key === 'ANTHROPIC_BASE_URL') baseUrl = value;
+  }
+} catch (err) {
+  console.error('Error: Cannot read config file:', configPath);
+  console.error(err.message);
   process.exit(1);
 }
 
-// Validate ANTHROPIC_BASE_URL
+// Also allow env vars to override config file
+authToken = process.env.ANTHROPIC_AUTH_TOKEN || authToken;
+baseUrl = process.env.ANTHROPIC_BASE_URL || baseUrl;
+
+if (!authToken) {
+  console.error('Error: ANTHROPIC_AUTH_TOKEN is not set in ~/.glm-config or environment');
+  process.exit(1);
+}
+
 if (!baseUrl) {
-  console.error('Error: ANTHROPIC_BASE_URL is not set');
-  console.error('');
-  console.error('Set the environment variable and retry:');
-  console.error('  export ANTHROPIC_BASE_URL="https://api.z.ai/api/anthropic"');
-  console.error('  or');
-  console.error('  export ANTHROPIC_BASE_URL="https://open.bigmodel.cn/api/anthropic"');
+  console.error('Error: ANTHROPIC_BASE_URL is not set in ~/.glm-config or environment');
   process.exit(1);
 }
 
@@ -37,7 +61,6 @@ let modelUsageUrl;
 let toolUsageUrl;
 let quotaLimitUrl;
 
-// Extract the base domain from ANTHROPIC_BASE_URL
 const parsedBaseUrl = new URL(baseUrl);
 const baseDomain = `${parsedBaseUrl.protocol}//${parsedBaseUrl.host}`;
 
@@ -62,6 +85,7 @@ if (baseUrl.includes('api.z.ai')) {
 
 console.log(`Platform: ${platform}`);
 console.log('');
+
 // Time window: from yesterday at the current hour (HH:00:00) to today at the current hour end (HH:59:59).
 const now = new Date();
 const startDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1, now.getHours(), 0, 0, 0);
@@ -84,31 +108,7 @@ const endtime = formatDateTime(endDate);
 // Properly encode query parameters
 const queryParams = `?startTime=${encodeURIComponent(startTime)}&endTime=${encodeURIComponent(endtime)}`;
 
-const processQuotaLimit = (data) => {
-  if (!data || !data.limits) return data;
-  
-  data.limits = data.limits.map(item => {
-    if (item.type === 'TOKENS_LIMIT') {
-      return {
-        type: 'Token usage(5 Hour)',
-        percentage: item.percentage
-      };
-    }
-    if (item.type === 'TIME_LIMIT') {
-      return {
-        type: 'MCP usage(1 Month)',
-        percentage: item.percentage,
-        currentUsage: item.currentValue,
-        totol: item.usage,
-        usageDetails: item.usageDetails
-      };
-    }
-    return item;
-  });
-  return data;
-};
-
-const queryUsage = (apiUrl, label, appendQueryParams = true, postProcessor = null) => {
+const queryUsage = (apiUrl, label, appendQueryParams = true) => {
   return new Promise((resolve, reject) => {
     const parsedUrl = new URL(apiUrl);
     const options = {
@@ -140,10 +140,7 @@ const queryUsage = (apiUrl, label, appendQueryParams = true, postProcessor = nul
 
         try {
           const json = JSON.parse(data);
-          let outputData = json.data || json;
-          if (postProcessor && json.data) {
-            outputData = postProcessor(json.data);
-          }
+          const outputData = json.data || json;
           console.log(JSON.stringify(outputData));
         } catch (e) {
           console.log('Response body:');
@@ -166,7 +163,7 @@ const queryUsage = (apiUrl, label, appendQueryParams = true, postProcessor = nul
 const run = async () => {
   await queryUsage(modelUsageUrl, 'Model usage');
   await queryUsage(toolUsageUrl, 'Tool usage');
-  await queryUsage(quotaLimitUrl, 'Quota limit', false, processQuotaLimit);
+  await queryUsage(quotaLimitUrl, 'Quota limit', false);
 };
 
 run().catch((error) => {


### PR DESCRIPTION
## Changes

### New Scripts
- **window-manager.py** — Auto-manage GLM 5h token windows
  - 4 active slots (06:00/11:00/16:00/21:00) + silent buffer (02:00-06:00)
  - Smart 0% detection: only claim window when no nextResetTime (avoid claiming stale unused windows)
  - Discord DM notifications on window refresh/active with timestamps
  - Standard Python logging to file + stdout

- **daily-summary.py** — Daily GLM usage report (cron 08:00)
- **weekly-summary.py** — Weekly GLM usage report (cron Mon 08:00)

### Fixes
- 0% token window detection: previously would claim any 0% window, now checks if nextResetTime exists to avoid claiming stale windows that have been alive but unused

### Other
- .gitignore for log files
- Minor refactoring in query-usage.mjs