### PR TITLE
Add version-sentinel: dependency-version guardrail plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,6 +19,15 @@
       "source": "./plugins/glm-plan-bug",
       "category": "development",
       "description": "Submit case feedback and bug reports for GLM Coding Plan service."
+    },
+    {
+      "name": "version-sentinel",
+      "source": {
+        "source": "github",
+        "repo": "KSEGIT/Version-Sentinel"
+      },
+      "category": "security",
+      "description": "Hard-blocks dependency additions and version changes until a fresh, source-cited version check is recorded. Supports npm, pip, Poetry/uv, Cargo, and NuGet."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A collection of plugins to enhance coding productivity and provide GLM Coding Pl
 |----------------------|-----------------------------------------------------------------------|
 | **glm-plan-usage**   | Query quota and usage statistics for GLM Coding Plan                  |
 | **glm-plan-bug**     | Submit case feedback and bug reports for GLM Coding Plan              |
+| **version-sentinel** | Hard-blocks dependency additions and version changes until a fresh, source-cited version check is recorded (npm, pip, Poetry/uv, Cargo, NuGet) — third-party, from [KSEGIT/Version-Sentinel](https://github.com/KSEGIT/Version-Sentinel) |
 
 **Attention:** **glm-plan-bug** will summarize your current conversation context to help identify issues. If you do not want to report this information, please do not actively use this plugin.
 


### PR DESCRIPTION
## What

Adds [version-sentinel](https://github.com/KSEGIT/Version-Sentinel) to the marketplace as a third-party plugin via a `github` source — no files vendored into this repo.

## What the plugin does

A PreToolUse guardrail for Claude Code that hard-blocks dependency additions, bumps, and downgrades (manifest edits via Edit/Write, and install commands via Bash) until the agent has verified the package version against its upstream registry (npmjs.com, pypi.org, crates.io, nuget.org) and recorded a source-cited check. It stops hallucinated versions, stale training-data pins, silent downgrades, and compromised-release installs. Supports npm/pnpm/yarn/bun, pip/Poetry/uv, Cargo, and NuGet. Ships `/vs-record` and `/check-versions` commands and escape hatches for intentional pins and offline sessions. MIT licensed.

## Why here

The GLM Coding Plan runs inside Claude Code, so Claude-format plugins benefit Z.ai users directly. Version-checking is especially relevant for GLM coding sessions: the guardrail forces a live registry lookup instead of trusting a model's memorized package versions.

## Verification

- `claude plugin marketplace add` + `claude plugin install` from the plugin's own marketplace verified working (plugin loads, hooks fire, block/unblock cycle confirmed).
- Entry schema matches the two existing plugins; `source` uses the marketplace-schema `github` form. `.claude-plugin/marketplace.json` is valid JSON.

Happy to adjust category, description wording, or the README row placement.