### PR TITLE
feat: add aeon plugin to the marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,6 +19,16 @@
       "source": "./plugins/glm-plan-bug",
       "category": "development",
       "description": "Submit case feedback and bug reports for GLM Coding Plan service."
+    },
+    {
+      "name": "aeon",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/aeonfun/aeon.git",
+        "path": "plugin"
+      },
+      "category": "productivity",
+      "description": "Set up and run your own Aeon autonomous agent instance - enable, schedule, edit, and debug skills that run on GitHub Actions."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A collection of plugins to enhance coding productivity and provide GLM Coding Pl
 |----------------------|-----------------------------------------------------------------------|
 | **glm-plan-usage**   | Query quota and usage statistics for GLM Coding Plan                  |
 | **glm-plan-bug**     | Submit case feedback and bug reports for GLM Coding Plan              |
+| **aeon**             | Set up and run your own Aeon autonomous agent instance               |
 
 **Attention:** **glm-plan-bug** will summarize your current conversation context to help identify issues. If you do not want to report this information, please do not actively use this plugin.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,6 +10,7 @@ Claude Code 插件集合，旨在提升编程效率和提供 GLM Coding Plan 相
 |---------------------|------------------------------------|
 | **glm-plan-usage**  | 查询 GLM Coding Plan 的配额和使用统计        |
 | **glm-plan-bug**    | 提交 GLM Coding Plan 的反馈和问题报告        |
+| **aeon**            | 搭建并运行你自己的 Aeon 自主智能体实例          |
 
 **注意:** **glm-plan-bug** 会总结您当前对话的上下文信息以帮助定位问题，若不想上报信息，请勿主动使用此插件。
 


### PR DESCRIPTION
Adds **aeon** to the marketplace: an operator-console plugin for setting up and running your own Aeon autonomous agent instance from Claude Code (enable/schedule/edit skills, wire secrets and channels, debug runs, and turn past coding-agent chats into scheduled skills). Aeon runs your own skills on a schedule in GitHub Actions; this plugin ships the single operator skill.

The plugin lives in the `plugin/` subdirectory of https://github.com/aeonfun/aeon (MIT, has its own `.claude-plugin/plugin.json`), so I referenced it with a `git-subdir` source rather than vendoring a copy:

```json
{
  "name": "aeon",
  "source": {
    "source": "git-subdir",
    "url": "https://github.com/aeonfun/aeon.git",
    "path": "plugin"
  },
  "category": "productivity",
  "description": "Set up and run your own Aeon autonomous agent instance ..."
}
```

Install once merged:

```shell
claude plugin install aeon@zai-coding-plugins
```

Also added a matching row to `README.md` and `README_CN.md`. No existing entries changed. Happy to adjust the category, wording, or switch to a vendored `./plugins/aeon` copy if you'd prefer that over a remote source.
